### PR TITLE
added a note that Big Sur PDF/A files are not PDS4 compliant.

### DIFF
--- a/other_tools/pdf1a.html
+++ b/other_tools/pdf1a.html
@@ -154,6 +154,14 @@
             have a way of converting their files into PDF, but it is
             not PDF/A compliant.
         </p>
+
+        <p>
+            MacOS Big Sur has a feature that will convert 
+            files to PDF/A, but this will produce a PDF/A 2-B file, which is 
+            not compatible with PDF/A 1-A or PDF/A 1-B. PDF/A 2-B is not 
+            currently supported by the PDS4 standards.
+        </p>
+
         <br><br>
 
     </div></main>


### PR DESCRIPTION
It turns out that the PDF/A files produced by MacOS Big Sur are not compliant with the PDS4 standards. Big Sur produces PDF/A 2-B files, which are not compatible with PDF/A 1-A or 1-B.